### PR TITLE
Respect mailmap files when generating git logs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Adam Tornhill <adam@adamtornhill.com> Adam Petersen <adam@adampetersen.se>
+robertc <robert@logicalchaos.org> LogicalChaos <robert@logicalchaos.org>
+Adam Tornhill <adam@adamtornhill.com> Adam Petersen Tornhill <adam@adampetersen.se>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To analyze our VCS data we need to define a temporal period of interest. Over ti
 
 #### Generate a git log file using the following command:
 
-          git log --pretty=format:'[%h] %an %ad %s' --date=short --numstat --after=YYYY-MM-DD
+          git log --pretty=format:'[%h] %aN %ad %s' --date=short --numstat --after=YYYY-MM-DD
 
 #### Generate a Mercurial log file using the following command:
 


### PR DESCRIPTION
Authors can have multiple names or email addresses configured when committing code and this can affect the analysis done by code-maat, especially if we are running `author-churn`.

We can have a `.mailmap` file to merge the different email/names used and generate the log using `%aN` instead of `%an` - I created a simple `.mailmap` file to illustrate that but I'm not sure I picked your preferred config :)

Before the fix:

```
$ git shortlog -sne
   152  Adam Petersen <adam@adampetersen.se>
    34  Adam Tornhill <adam@adamtornhill.com>
     2  Felipe Knorr Kuhn <git@knorrium.info>
     2  robertc <robert@logicalchaos.org>
     1  Adam Petersen Tornhill <adam@adampetersen.se>
     1  LogicalChaos <robert@logicalchaos.org>
```

```
$ java -jar target/code-maat-0.8.5-standalone.jar -l code-maat.log -c git -a author-churn
author,added,deleted
Adam Petersen,16367,2766
Adam Petersen Tornhill,3,3
Adam Tornhill,591,304
Felipe Knorr Kuhn,4,1
LogicalChaos,38,56
robertc,251,20
```

After the fix:

```
$ git shortlog -sne
   187  Adam Tornhill <adam@adamtornhill.com>
     3  robertc <robert@logicalchaos.org>
     2  Felipe Knorr Kuhn <git@knorrium.info>
```

```
$ java -jar target/code-maat-0.8.5-standalone.jar -l code-maat-mailmap.log -c git -a author-churn
author,added,deleted
Adam Tornhill,16961,3073
Felipe Knorr Kuhn,4,1
robertc,289,76
```