### PR TITLE
missing parens in require

### DIFF
--- a/test/code_maat/parsers/mercurial_test.clj
+++ b/test/code_maat/parsers/mercurial_test.clj
@@ -4,7 +4,7 @@
 ;;; see http://www.gnu.org/licenses/gpl.html
 
 (ns code-maat.parsers.mercurial-test
-  (:require [code-maat.parsers.mercurial :as hg]
+  (:require [code-maat.parsers.mercurial :as hg])
   (:use clojure.test incanter.core))
 
 (def ^:const entry


### PR DESCRIPTION
So incredibly that file had unmatched parenthesis..
I'm not sure why it doesn't actually fail with the old Lein but well..
Running lein test for that namespace still fails but now I think it's a real error now.

````
ERROR in (parses-empty-log-to-empty-dataset) (FileInputStream.java:-2)
expected: (= (hg/parse-log "" {}) [])
  actual: java.io.FileNotFoundException:  (No such file or directory)
 at java.io.FileInputStream.open (FileInputStream.java:-2)
    java.io.FileInputStream.<init> (FileInputStream.java:146)
    clojure.java.io/fn (io.clj:229)
    clojure.java.io$fn__8615$G__8606__8622.invoke (io.clj:69)
    clojure.java.io/fn (io.clj:258)
    clojure.java.io$fn__8615$G__8606__8622.invoke (io.clj:69)
    clojure.java.io/fn (io.clj:165)
    clojure.java.io$fn__8628$G__8610__8635.invoke (io.clj:69)
    clojure.java.io$reader.doInvoke (io.clj:102)
    clojure.lang.RestFn.invoke (RestFn.java:439)
    code_maat.parsers.hiccup_based_parser$parse_log.invoke (hiccup_based_parser.clj:171)
    code_maat.parsers.mercurial$parse_log.invoke (mercurial.clj:56)
    code_maat.parsers.mercurial_test/fn (mercurial_test.clj:35)
    clojure.test$test_var$fn__7187.invoke (test.clj:704)
    clojure.test$test_var.invoke (test.clj:704)
    clojure.test$test_vars$fn__7209$fn__7214.invoke (test.clj:722)
    clojure.test$default_fixture.invoke (test.clj:674)
    clojure.test$test_vars$fn__7209.invoke (test.clj:722)
    clojure.test$default_fixture.invoke (test.clj:674)
    clojure.test$test_vars.invoke (test.clj:718)
    clojure.test$test_all_vars.invoke (test.clj:728)
    clojure.test$test_ns.invoke (test.clj:747)
    clojure.core$map$fn__4245.invoke (core.clj:2559)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1654)
    clojure.lang.RestFn.applyTo (RestFn.java:130)
    clojure.core$apply.invoke (core.clj:626)
    clojure.test$run_tests.doInvoke (test.clj:762)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:624)
    user$eval132$fn__187$fn__218.invoke (form-init4942950767034387962.clj:1)
    user$eval132$fn__187$fn__188.invoke (form-init4942950767034387962.clj:1)
    user$eval132$fn__187.invoke (form-init4942950767034387962.clj:1)
    user$eval132.invoke (form-init4942950767034387962.clj:1)
    clojure.lang.Compiler.eval (Compiler.java:6703)
    clojure.lang.Compiler.eval (Compiler.java:6693)
    clojure.lang.Compiler.load (Compiler.java:7130)
    clojure.lang.Compiler.loadFile (Compiler.java:7086)
    clojure.main$load_script.invoke (main.clj:274)
    clojure.main$init_opt.invoke (main.clj:279)
    clojure.main$initialize.invoke (main.clj:307)
    clojure.main$null_opt.invoke (main.clj:342)
    clojure.main$main.doInvoke (main.clj:420)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)

Ran 3 tests containing 3 assertions.
0 failures, 3 errors.
Tests failed.

```