### PR TITLE
add a simple test for command line parsing

### DIFF
--- a/test/code_maat/app/cmd_line_test.clj
+++ b/test/code_maat/app/cmd_line_test.clj
@@ -1,0 +1,12 @@
+(ns code-maat.app.cmd-line-test
+  (:require  [clojure.test :refer :all]
+             [clojure.tools.cli :as cli]
+             [code-maat.cmd-line :refer :all]))
+
+
+(deftest test-argument-parsing
+  (testing "simple cmd line parsing"
+    (let [args ["-l some_file.log"]
+          parsed-options (cli/parse-opts args cli-options)]
+
+      (is (nil? (:errors parsed-options))))))


### PR DESCRIPTION
I was running "lein cloverage" and I noticed that the cmd-line.clj file is not really tested..

There are some tests end-to-end which however don't really go through cmd-line.clj, maybe they should?

Anyway I was thinking that the argument validation should ideally be done before we pass things to app/run and that's why I just added this simple test..

In case the validation gets moved or there are some more complex things in the arguments this might come handy.
What do you think in general about moving somewhere else the logic for the arguments validation?

(for example for the other branch I'm working on I will need to add at least another command).
Thanks