### PR TITLE
Bugfix: Parse author non-greedy

### DIFF
--- a/src/code_maat/parsers/git.clj
+++ b/src/code_maat/parsers/git.clj
@@ -35,7 +35,7 @@
     entry     = <prelude*> prelude changes (* covers pull requests *)
     <prelude> = rev <ws> author <ws> date <ws> message <nl>
     rev       =  <'['> #'[\\da-f]+' <']'>
-    author    =  #'.+(?=\\s\\d{4}-\\d{2}-\\d{2})' (* match until the date field *)
+    author    =  #'.+?(?=\\s\\d{4}-\\d{2}-\\d{2})' (* match until the date field *)
     date      =  #'\\d{4}-\\d{2}-\\d{2}'
     message   =  #'[^\\n]*'
     changes   =  change*

--- a/test/code_maat/parsers/git_test.clj
+++ b/test/code_maat/parsers/git_test.clj
@@ -34,6 +34,9 @@
 0	7	test/code_maat/end_to_end/scenario_tests.clj
 18	0	test/code_maat/end_to_end/simple_git.txt
 21	0	test/code_maat/end_to_end/svn_live_data_test.clj
+
+[a32793d] Ola Flisbäck 2015-09-29 Corrected date of self-awareness to 1997-08-29
+1	1	README.md
 ")
 
 (def ^:const pull-requests
@@ -107,7 +110,11 @@
           {:loc-deleted "0" :loc-added "21"
            :author "Adam Petersen" :rev "a527b79" :date "2013-08-29"
            :entity "test/code_maat/end_to_end/svn_live_data_test.clj"
-           :message "git: proper error messages from instaparse"}])))
+           :message "git: proper error messages from instaparse"}
+          {:loc-deleted "1" :loc-added "1",
+           :author "Ola Flisbäck" :rev "a32793d" :date "2015-09-29"
+           :entity "README.md"
+           :message "Corrected date of self-awareness to 1997-08-29"}])))
 
 (deftest parses-empty-log-to-empty-dataset
   (is (= (parse "")


### PR DESCRIPTION
The author regex for the git parser now consumes everything up to
the first date instead of the last.