### PR TITLE
Broadening TFS Coverage

### DIFF
--- a/src/code_maat/parsers/tfs.clj
+++ b/src/code_maat/parsers/tfs.clj
@@ -88,7 +88,7 @@
    :author  #(get-in % [2 1])
    :changes #(rest (get-in % [5]))
    :message (fn [entry] (let [message (get-in entry [4])]
-                          (str/join "\n  " (rest message))))})
+                          (str/join "\n" (rest message))))})
 
 (defn parse-log
 	"Transforms the given input TFS log into an 
@@ -105,4 +105,3 @@
                       options
                       tfs-grammar
                       positional-extractors))
-

--- a/src/code_maat/parsers/tfs.clj
+++ b/src/code_maat/parsers/tfs.clj
@@ -42,7 +42,7 @@
 	 Things get parsed one-by-one for memory optimization
 	 TFS doesn't give us lines added/deleted, so we only get the core metrics"
 	"
-    changeset     = <sep> changelog userinfo <proxy?> timestamp message changes <nl*>
+    changeset     = <sep> changelog userinfo <proxy?> timestamp comment changes <nl*>
     sep           = '-'* <nl>
     <changelog>   = <'Changeset: '> id <nl>
     id            = #'[\\d]+'
@@ -51,7 +51,9 @@
     <proxy>       = <'Checked in by: '> #'.+' <nl>
     <timestamp>   = <'Date: '> date <nl>
     date          = #'.+'
-    message       = <'Comment:'> <nl> <'  '> #'[\\S ]+' <nl>
+    <comment>     = <'Comment:'> <nl> message
+    message       = line*
+    <line>        = <'  '> #'[\\S ]+' <nl>
     changes       = <'Items:'> <nl> file*
     file          = <ws+> <action+> <'$'> #'.+' <nl?>
     action        = #'[a-zA-Z, ]+'
@@ -85,7 +87,8 @@
                   (catch Exception e (throw (IllegalArgumentException. (str "Unsupported TFS Date Format: " date-string)))))))
    :author  #(get-in % [2 1])
    :changes #(rest (get-in % [5]))
-   :message #(get-in % [4 1])})
+   :message (fn [entry] (let [message (get-in entry [4])]
+                          (str/join "\n  " (rest message))))})
 
 (defn parse-log
 	"Transforms the given input TFS log into an 

--- a/src/code_maat/parsers/tfs.clj
+++ b/src/code_maat/parsers/tfs.clj
@@ -42,12 +42,13 @@
 	 Things get parsed one-by-one for memory optimization
 	 TFS doesn't give us lines added/deleted, so we only get the core metrics"
 	"
-    changeset     = <sep> changelog userinfo timestamp message changes <nl*>
+    changeset     = <sep> changelog userinfo <proxy?> timestamp message changes <nl*>
     sep           = '-'* <nl>
     <changelog>   = <'Changeset: '> id <nl>
     id            = #'[\\d]+'
     <userinfo>    = <'User: '> author <nl>
     author        = #'.+'
+    <proxy>       = <'Checked in by: '> #'.+' <nl>
     <timestamp>   = <'Date: '> date <nl>
     date          = #'.+'
     message       = <'Comment:'> <nl> <'  '> #'[\\S ]+' <nl>

--- a/test/code_maat/parsers/tfs_test.clj
+++ b/test/code_maat/parsers/tfs_test.clj
@@ -21,6 +21,21 @@ Items:
 
 ")
 
+(def ^:const long-comment-entry
+  "-----------------------------------------------------------------------------------------------------------------------
+Changeset: 5
+User: Ryan Coy
+Date: Thursday, July 23, 2015 4:34:31 PM
+
+Comment:
+  Created team project folder /Project via the Team Project Creation Wizard
+  ***NO_CI***
+
+Items:
+  add $/Project
+
+")
+
 (def ^:const proxy-checkin-entry
   "-----------------------------------------------------------------------------------------------------------------------
 Changeset: 5
@@ -100,6 +115,14 @@ Items:
            :date "2015-07-23"
            :entity "/Project"
            :message "Created team project folder /Project via the Team Project Creation Wizard"}])))
+
+(deftest parses-long-comment-to-dataset
+  (is (= (parse long-comment-entry)
+         [{:author "Ryan Coy"
+           :rev "5"
+           :date "2015-07-23"
+           :entity "/Project"
+           :message "Created team project folder /Project via the Team Project Creation Wizard\n  ***NO_CI***"}])))
 
 (deftest parses-proxy-checkin-to-dataset
   (is (= (parse proxy-checkin-entry)

--- a/test/code_maat/parsers/tfs_test.clj
+++ b/test/code_maat/parsers/tfs_test.clj
@@ -21,6 +21,21 @@ Items:
 
 ")
 
+(def ^:const proxy-checkin-entry
+  "-----------------------------------------------------------------------------------------------------------------------
+Changeset: 5
+User: Ryan Coy
+Checked in by: build.server
+Date: Thursday, July 23, 2015 4:34:31 PM
+
+Comment:
+  Created team project folder /Project via the Team Project Creation Wizard
+
+Items:
+  add $/Project
+
+")
+
 (def ^:const en-gb-entry
   "-----------------------------------------------------------------------------------------------------------------------
 Changeset: 5
@@ -80,6 +95,14 @@ Items:
 
 (deftest parses-en-us-entry-to-dataset
   (is (= (parse en-us-entry)
+         [{:author "Ryan Coy"
+           :rev "5"
+           :date "2015-07-23"
+           :entity "/Project"
+           :message "Created team project folder /Project via the Team Project Creation Wizard"}])))
+
+(deftest parses-proxy-checkin-to-dataset
+  (is (= (parse proxy-checkin-entry)
          [{:author "Ryan Coy"
            :rev "5"
            :date "2015-07-23"

--- a/test/code_maat/parsers/tfs_test.clj
+++ b/test/code_maat/parsers/tfs_test.clj
@@ -122,7 +122,7 @@ Items:
            :rev "5"
            :date "2015-07-23"
            :entity "/Project"
-           :message "Created team project folder /Project via the Team Project Creation Wizard\n  ***NO_CI***"}])))
+           :message "Created team project folder /Project via the Team Project Creation Wizard\n***NO_CI***"}])))
 
 (deftest parses-proxy-checkin-to-dataset
   (is (= (parse proxy-checkin-entry)


### PR DESCRIPTION
This is a couple of fixes for the TFS parser:
1.  There are cases where changesets can be checked-in by proxy(usually a build server)
2.  TFS allows for multi-line changeset messages