### PR TITLE
Enforce the pre-conditions on the messages analysis

### DIFF
--- a/src/code_maat/analysis/commit_messages.clj
+++ b/src/code_maat/analysis/commit_messages.clj
@@ -32,11 +32,6 @@
      (IllegalArgumentException.
       "Commit messages: you need to provide an expression to match against."))))
 
-(defn- columns-of-interest
-  "Filter away all the data we won't need (less GC overhead)."
-  [ds]
-  (dataset/-select-by [:entity :message] ds))
-
 (defn- commit-matches
   "Performs a match for the expression provided by the
    user against a single commit message."

--- a/src/code_maat/app/app.clj
+++ b/src/code_maat/app/app.clj
@@ -210,6 +210,8 @@
     (output-fn! (analysis-fn changes))
     (catch AssertionError e ; typically a pre- or post-condition
       (throw-internal-error e))
+    (catch IllegalArgumentException e
+      (throw e))
     (catch Exception e
       (throw-internal-error e))))
 

--- a/test/code_maat/end_to_end/scenario_tests.clj
+++ b/test/code_maat/end_to_end/scenario_tests.clj
@@ -106,6 +106,15 @@
   (is (= (run-with-str-output log-file options)
          "author,peer,shared,average,strength\nXYZ,APT,1,2,50\nAPT,XYZ,1,2,50\n")))
 
+(defn- with-message-to-match
+  [options msg]
+  (assoc options :expression-to-match  msg))
+
+(deftest counts-commit-message-patterns
+  (is (= (run-with-str-output git-log-file
+                              (with-message-to-match (git-options "messages")"stat"))
+         "entity,matches\n/Infrastrucure/Network/Connection.cs,1\n")))
+
 ;;; The identity analysis is intended as a debug aid or to
 ;;; generate parsed VCS data as input to other tools.
 ;;; The idea with identity is to dump the parse result to
@@ -144,7 +153,7 @@
 
 (deftest reports-invalid-arguments
   (testing "Non-existent input file"
-    (is (thrown? IllegalArgumentException (app/run "I/do/not/exist"))))
+    (is (thrown? IllegalArgumentException (app/run "I/do/not/exist" {}))))
   (testing "Missing mandatory options (normally added by the front)"
     (is (thrown? IllegalArgumentException (app/run svn-log-file {:analysis "coupling"})))))
 


### PR DESCRIPTION
Solves issue #57

The `messages` analysis requires a commit message. The commit message isn't included in the `git2` format, and hence the analysis doesn't find anything to analyse. The old behavior was to simply return an empty result set. This was confusing, so I've changed it do fail instead.

Note that the message analysis can easily be done from a shell via `git log --pretty=format:'%s' | grep -o "[Bb]ug"`