### PR TITLE
Increase RAM associated to JVM in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN lein deps
 COPY . $dest
 RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app-standalone.jar
 
-ENTRYPOINT ["java", "-jar", "app-standalone.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=85.0", "-XX:+UnlockExperimentalVMOptions", "-jar", "app-standalone.jar"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN lein deps
 COPY . $dest
 RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app-standalone.jar
 
-ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=85.0", "-XX:+UnlockExperimentalVMOptions", "-jar", "app-standalone.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=85.0", "-jar", "app-standalone.jar"]
 CMD []


### PR DESCRIPTION
## Summary

This pull request changes the Dockerfile such, that code-maat can allocate up to 85% of the memory assigned to the container.

## Why?

When analyzing a large code base using the docker container, **the application can run out of memory**. In the current configuration, `docker stats` shows that code-maat jvm / clojure process can only access 30% of the memory assigned to the container.

In my setup I needed to assign 12 GB to the container in order to finish my analysis. With the change in place, the default 2 GB RAM for Docker Desktop are sufficient.

The suggested change is based on the recommendations by [Diogok: Efficient Clojure multistage docker images, with java and native-image](https://medium.com/@diogok/efficient-clojure-multistage-docker-images-with-java-and-native-image-c7c80b93c8).