### PR TITLE
Introduce verbose output for change coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,16 @@ The resulting output is on CSV format:
               InfoUtils.java,  BarChart.java,  62,      45
               ...
 
-In the example above, the first column (`entity`) gives us the name of the module, the second (`coupled`) gives us the name of a logically coupled module, the third column (`degree`) gives us the coupling as a percentage (0-100), and finally `average-revs` gives us the average number of revisions of the two modules. To interpret the data, consider the `InfoUtils.java` module in the example output above. The coupling tells us that each time it's modified, it's a 78% risk/chance that we'll have to change our `Page.java` module too. Since there's probably no reason they should change together, the analysis points to a part of the code worth investigating as a potential target for a future refactoring.
+In the example above, the first column (`entity`) gives us the name of the module, the second (`coupled`) gives us the name of a logically
+coupled module, the third column (`degree`) gives us the coupling as a percentage (0-100), and finally `average-revs` gives us the average number of revisions
+of the two modules.
+
+To interpret the data, consider the `InfoUtils.java` module in the example output above.
+The coupling tells us that each time it's modified, it's a 78% risk/chance that we'll have to change our `Page.java` module too.
+Since there's probably no reason they should change together, the analysis points to a part of the code worth investigating as a potential target for a future refactoring.
+
+*Advanced*: the coupling analysis also supports `--verbose-results`. In verbose mode, the coupling analysis also includes the number of revisions for each coupled entity together
+with the number of shared revisions. The main use cases for this option are a) build custom filters to reduce noise, or b) research studies.
 
 ### Calculate code age
 

--- a/src/code_maat/cmd_line.clj
+++ b/src/code_maat/cmd_line.clj
@@ -35,11 +35,12 @@
    ["-t" "--temporal-period TEMPORAL-PERIOD"
     "Used for coupling analyses. Instructs Code Maat to consider all commits during the rolling temporal period as a single, logical commit set"]
    ["-d" "--age-time-now AGE-TIME_NOW" "Specify a date as YYYY-MM-dd that counts as time zero when doing a code age analysis"]
+   [nil  "--verbose-results" "Includes additional analysis details together with the results. Only implemented for change coupling."]
    ["-h" "--help"]])
 
 (defn- usage [options-summary]
   (->> ["This is Code Maat, a program used to collect statistics from a VCS."
-        "Version: 1.0-SNAPSHOT"
+        "Version: 1.0.5-SNAPSHOT"
         ""
         "Usage: program-name -l log-file [options]"
         ""

--- a/test/code_maat/analysis/logical_coupling_test.clj
+++ b/test/code_maat/analysis/logical_coupling_test.clj
@@ -30,14 +30,25 @@
 
 (def ^:const revd (incanter/to-dataset one-revision))
 
+(def ^:private default-options test-data/options-with-low-thresholds)
+
 (deftest calculates-coupling-by-degree
   (is (= (incanter/to-list (coupling/by-degree
                             coupledd
-                            test-data/options-with-low-thresholds))
+                            default-options))
          ;; :entity :coupled :degree :average-revs
          [["A"      "B"       100   2]
           ["A"      "C"       66    2]
           ["B"      "C"       66    2]])))
+
+(deftest outputs-verbose-details-when-prompted-to
+  (is (= (incanter/to-list (coupling/by-degree
+                             coupledd
+                             (assoc default-options :verbose-results true)))
+         ;; :entity :coupled :degree :average-revs revs1 revs2 shared-revs
+         [["A"      "B"       100     2            2     2     2]
+          ["A"      "C"       66      2            2     1     1]
+          ["B"      "C"       66      2            2     1     1]])))
 
 (deftest gives-empty-result-for-single-change-set-with-single-entity
   "A single change set with a single entity (boundary case)"

--- a/test/code_maat/end_to_end/scenario_tests.clj
+++ b/test/code_maat/end_to_end/scenario_tests.clj
@@ -88,6 +88,19 @@
   (is (= (run-with-str-output log-file options)
          "entity,coupled,degree,average-revs\n/Infrastrucure/Network/Connection.cs,/Presentation/Status/ClientPresenter.cs,66,2\n")))
 
+(defn- ->verbose
+  [options]
+  (assoc options :verbose-results true))
+
+(def-data-driven-with-vcs-test verbose-change-coupling
+   [[svn-log-file  (-> "coupling" svn-csv-options ->verbose)]
+    [git-log-file  (-> "coupling" git-options ->verbose)]
+    [git2-log-file (-> "coupling" git2-options ->verbose)]
+    [p4-log-file   (-> "coupling" p4-options ->verbose)]
+    [hg-log-file   (-> "coupling" hg-options ->verbose)]]
+   (is (= (run-with-str-output log-file options)
+          "entity,coupled,degree,average-revs,first-entity-revisions,second-entity-revisions,shared-revisions\n/Infrastrucure/Network/Connection.cs,/Presentation/Status/ClientPresenter.cs,66,2,2,1,1\n")))
+
 (def-data-driven-with-vcs-test analysis-of-effort
   [[svn-log-file (svn-csv-options "entity-effort")]
    [git-log-file (git-options "entity-effort")]


### PR DESCRIPTION
This PR adds a new command line option, `--verbose-results`. See the updated `README.md` for details.